### PR TITLE
Provided a default value for the name argument. 

### DIFF
--- a/FieryCrucible/DependencyFactory.swift
+++ b/FieryCrucible/DependencyFactory.swift
@@ -83,7 +83,7 @@ public class DependencyFactory {
     
     public init() { }
     
-    public func shared<T>(name: String, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
+    public func shared<T>(name: String = __FUNCTION__, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
         return inject(
             lifecyle: .Shared,
             name: name,
@@ -94,7 +94,7 @@ public class DependencyFactory {
         )
     }
     
-    public func weakShared<T: AnyObject>(name: String, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
+    public func weakShared<T: AnyObject>(name: String = __FUNCTION__, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
         return inject(
             lifecyle: .WeakShared,
             name: name,
@@ -105,7 +105,7 @@ public class DependencyFactory {
         )
     }
     
-    public func unshared<T>(name: String, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
+    public func unshared<T>(name: String = __FUNCTION__, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
         var unsharedInstances: [String:AnyObject] = [:]
         return inject(
             lifecyle: .Unshared,
@@ -117,7 +117,7 @@ public class DependencyFactory {
         )
     }
     
-    public func scoped<T>(name: String, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
+    public func scoped<T>(name: String = __FUNCTION__, @autoclosure factory: () -> T, configure configureOrNil: ((T) -> ())? = nil) -> T {
         return inject(
             lifecyle: .Scoped,
             name: name,


### PR DESCRIPTION
Now the caller does not need to pass this unless they would like a custom unique key.